### PR TITLE
Use the latest tag

### DIFF
--- a/miner_latest.sh
+++ b/miner_latest.sh
@@ -22,7 +22,10 @@ do
 done
 
 # Autodetect running image version and set arch
-image=$(docker container inspect -f '{{.Config.Image}}' miner)
+image=$(docker container inspect -f '{{.Config.Image}}' $MINER 2>/dev/null) || {
+   echo "The $MINER container isn't running, aborting."
+   exit 1
+}
 
 echo "Fetching the latest version"
 docker pull $image > /dev/null

--- a/miner_latest.sh
+++ b/miner_latest.sh
@@ -47,7 +47,7 @@ docker images quay.io/team-helium/miner -f "before=$image" --format "{{.ID}}" | 
 
 echo "Provisioning new miner version"
 
-docker run -d --env REGION_OVERRIDE=$REGION --restart always --publish $GWPORT:$GWPORT/udp --publish $MINERPORT:$MINERPORT/tcp --name $MINER --mount type=bind,source=$DATADIR,target=/var/data quay.io/team-helium/miner:latest-amd64
+docker run -d --env REGION_OVERRIDE=$REGION --restart always --publish $GWPORT:$GWPORT/udp --publish $MINERPORT:$MINERPORT/tcp --name $MINER --mount type=bind,source=$DATADIR,target=/var/data $image
 
 if [ $GWPORT -ne 1680 ] || [ $MINERPORT -ne 44158 ]; then
    echo "Using nonstandard ports, adjusting miner config"

--- a/miner_latest.sh
+++ b/miner_latest.sh
@@ -9,12 +9,6 @@ GWPORT=1680
 MINERPORT=44158
 DATADIR=/home/pi/miner_data
 
-testJQ=$(which jq)
-
-if [ $? -ne 0 ]; then
-       	sudo apt install jq curl -y 
-fi
-
 # Read switches to override any default values for non-standard configs
 while getopts n:g:p:d:r: flag
 do
@@ -28,67 +22,32 @@ do
 done
 
 # Autodetect running image version and set arch
-running_image=$(docker container inspect -f '{{.Config.Image}}' $MINER | awk -F: '{print $2}')
-if [ -z "$running_image" ]; then
-	ARCH=arm
-elif [ `echo $running_image | awk -F_ '{print $1}'` == "miner-arm64" ]; then
-	ARCH=arm
-elif [ `echo $running_image | awk -F_ '{print $1}'` == "miner-amd64" ]; then 
-	ARCH=amd
-else
-	ARCH=arm
-	#below is just to make it not null.
-	running_image=" "
-fi
+image=$(docker container inspect -f '{{.Config.Image}}' miner)
 
-#miner_latest=$(curl -s 'https://quay.io/api/v1/repository/team-helium/miner/tag/?limit=100&page=1&onlyActiveTags=true' | jq -c --arg ARCH "$ARCH" '[ .tags[] | select( .name | contains($ARCH)) ][0].name' | cut -d'"' -f2)
+echo "Fetching the latest version"
+docker pull $image > /dev/null
 
-miner_quay=$(curl -s 'https://quay.io/api/v1/repository/team-helium/miner/tag/?limit=100&page=1&onlyActiveTags=true' --write-out '\nHTTP_Response:%{http_code}')
+# Compare image ids
+image_id=$(docker image inspect --format '{{.Id}}' $image)
+running_id=$(docker inspect --format '{{.Image}}' $MINER)
 
-miner_response=$(echo "$miner_quay" | grep "HTTP_Response" | cut -d":" -f2)
-
-if [[ $miner_response -ne 200 ]];
-	then
-	echo "Bad Response from Server"
-	exit 0
-fi
-
-miner_latest=$(echo "$miner_quay" | grep -v HTTP_Response | jq -c --arg ARCH "$ARCH" '[ .tags[] | select( .name | contains($ARCH)) ][0].name' | cut -d'"' -f2)
-
-date
-
-if `echo $miner_latest | grep -q $ARCH`;
-then echo "Latest miner version" $miner_latest;
-elif miner_latest=$(curl -s 'https://quay.io/api/v1/repository/team-helium/miner/tag/?limit=100&page=1&onlyActiveTags=true' | jq -r .tags[1].name)
-then echo "Latest miner version" $miner_latest;
-fi
-
-if [ "$miner_latest" = "$running_image" ];
+if [ "$image_id" = "$running_id" ];
 then    echo "already on the latest version"
         exit 0
 fi
 
 echo "Stopping and removing old miner"
 
-docker stop $MINER && docker rm $MINER
+docker stop $MINER
+docker rm $MINER
 
 echo "Deleting old miner software"
 
-for a in `docker images quay.io/team-helium/miner | grep "quay.io/team-helium/miner" | awk '{print $3}'`; do
-	image_cleanup=$(docker images | grep $a | awk '{print $2}')
-	#change this to $running_image if you want to keep the last 2 images
-	if [ $image_cleanup = $miner_latest ]; then
-	       continue
-        else
-		echo "Cleaning up: " $image_cleanup
-	       	docker image rm $a
-        
-        fi		
-done
+docker images quay.io/team-helium/miner -f "before=$image" --format "{{.ID}}" | xargs docker image rm
 
 echo "Provisioning new miner version"
 
-docker run -d --env REGION_OVERRIDE=$REGION --restart always --publish $GWPORT:$GWPORT/udp --publish $MINERPORT:$MINERPORT/tcp --name $MINER --mount type=bind,source=$DATADIR,target=/var/data quay.io/team-helium/miner:$miner_latest
+docker run -d --env REGION_OVERRIDE=$REGION --restart always --publish $GWPORT:$GWPORT/udp --publish $MINERPORT:$MINERPORT/tcp --name $MINER --mount type=bind,source=$DATADIR,target=/var/data quay.io/team-helium/miner:latest-amd64
 
 if [ $GWPORT -ne 1680 ] || [ $MINERPORT -ne 44158 ]; then
    echo "Using nonstandard ports, adjusting miner config"


### PR DESCRIPTION
To illustrate how this works:

```
$ docker pull quay.io/team-helium/miner:latest-amd64
$ docker image inspect --format '{{.Id}}' quay.io/team-helium/miner:latest-amd64
sha256:447fccc05dd55afad938de562040d8b05dc5619a7f644b9ce6100cd26ff945ba
$ docker inspect --format '{{.Image}}' miner
sha256:447fccc05dd55afad938de562040d8b05dc5619a7f644b9ce6100cd26ff945ba
```

Basically, we fetch the `latest-$ARCH` tag, and Docker will only download it if it doesn't have it yet. Then, we just compare the image ID to the one of the running container, and if they are different we restart the container with the new version.

I also simplified most of the image cleaning, arch selection, etc.

I also removed the `jq` dependency as it already wasn't used anymore and assumed a Debian based OS.