### PR TITLE
Pull the new miner image before stopping the miner

### DIFF
--- a/miner_latest.sh
+++ b/miner_latest.sh
@@ -81,6 +81,9 @@ then    echo "already on the latest version"
         exit 0
 fi
 
+# Pull the new miner image. Downloading it now will minimize miner downtime after stop.
+docker pull quay.io/team-helium/miner:"$miner_latest"
+
 echo "Stopping and removing old miner"
 
 docker stop "$MINER" && docker rm "$MINER"


### PR DESCRIPTION
Downloading the new image can take some time. By pulling it
before stopping the miner, we make sure the image is available
for immediate start.