### PR TITLE
Add support for log directory

### DIFF
--- a/miner_latest.sh
+++ b/miner_latest.sh
@@ -104,7 +104,7 @@ echo "Provisioning new miner version"
 
 if [ -n "$LOGDIR" ];
 then
-	LOGMOUNT="--mount type=bind,source=$LOGDIR,target=/var/log"
+	LOGMOUNT="--mount type=bind,source=$LOGDIR,target=/var/data/log"
 fi
 
 docker run -d --init --env REGION_OVERRIDE="$REGION" --restart always --publish "$GWPORT":"$GWPORT"/udp --publish "$MINERPORT":"$MINERPORT"/tcp --name "$MINER" $LOGMOUNT --mount type=bind,source="$DATADIR",target=/var/data quay.io/team-helium/miner:"$miner_latest"


### PR DESCRIPTION
One of our miners got stuck in an endless crash-restart loop.
Having the logs inside the container made it hard to check what
was going on.

By mounting the log folder externally, the log files are easily
accessible.

If no log directory is given, logs will be kept inside the container
just as before.