### PR TITLE
miner_latest: Adjust snapshot memory limit

### DIFF
--- a/miner_latest.sh
+++ b/miner_latest.sh
@@ -113,6 +113,10 @@ docker run -d --init --env REGION_OVERRIDE="$REGION" --restart always --publish 
 if [ "$GWPORT" -ne 1680 ] || [ "$MINERPORT" -ne 44158 ]; then
    echo "Using nonstandard ports, adjusting miner config"
    docker exec "$MINER" sed -i "/^  {blockchain,/{N;s/$/\n      {port, $MINERPORT},/}; s/1680/$GWPORT/" /opt/miner/releases/0.1.0/sys.config
-   docker restart "$MINER"
 fi
+
+echo "Increasing memory limit for snapshots. See https://discord.com/channels/404106811252408320/730245219974381708/851336745538027550"
+docker exec "$MINER" sed -i 's/{key, undefined}$/{key, undefined},{snapshot_memory_limit, 1000}/' /opt/miner/releases/0.1.0/sys.config
+docker restart "$MINER"
+
 update-git


### PR DESCRIPTION
Taking snapshots often fails with
```
=ERROR REPORT==== 7-Jun-2021::09:52:48.174344 ===
     Process:          <8517.1435.0> on node 'miner@127.0.0.1'
     Context:          maximum heap size reached
     Max Heap Size:    9830400
     Total Heap Size:  11347378
     Kill:             true
     Error Logger:     true
```

By increasing the memory limit for snapshots, we make it possible to take snapshots.
More info: https://discord.com/channels/404106811252408320/730245219974381708/851336745538027550